### PR TITLE
fixed roi labels, added acquisition time start/end

### DIFF
--- a/iocs/photronIOC/iocBoot/iocPhotron/xml/hdf5_exchange_layout.xml
+++ b/iocs/photronIOC/iocBoot/iocPhotron/xml/hdf5_exchange_layout.xml
@@ -55,10 +55,10 @@
             <dataset name="num_recordings" source="ndattribute" ndattribute="NumRecordings" when="OnFileClose"></dataset>
           </group>
           <group name="roi">
-            <dataset name="pos_x" source="ndattribute" ndattribute="MinX" when="OnFileClose"></dataset>
-            <dataset name="pos_y" source="ndattribute" ndattribute="MinY" when="OnFileClose"></dataset>
-            <dataset name="size_x" source="ndattribute" ndattribute="SizeX" when="OnFileClose"></dataset>
-            <dataset name="size_y" source="ndattribute" ndattribute="SizeY" when="OnFileClose"></dataset>
+            <dataset name="x_min" source="ndattribute" ndattribute="MinX" when="OnFileClose"></dataset>
+            <dataset name="y_min" source="ndattribute" ndattribute="MinY" when="OnFileClose"></dataset>
+            <dataset name="x_size" source="ndattribute" ndattribute="SizeX" when="OnFileClose"></dataset>
+            <dataset name="y_size" source="ndattribute" ndattribute="SizeY" when="OnFileClose"></dataset>
           </group><!-- /roi -->
           <group name="irig">
             <dataset name="mem_irig" source="ndattribute" ndattribute="MemIRIG" when="OnFileClose"></dataset>
@@ -329,7 +329,6 @@
             <attribute name="units" source="constant" value="mm" type="string"></attribute>
           </dataset>
           <dataset name="mode" source="ndattribute" ndattribute="TopUpStatus" when="OnFileClose"></dataset>
-          <dataset name="datetime" source="ndattribute" ndattribute="DateTime" when="OnFileClose"></dataset>
         </group><!-- /source -->
         <group name="mirror">
           <dataset name="type" source="constant" value="Type of mirror" type="string" when="OnFileClose"></dataset>        

--- a/iocs/photronIOC/iocBoot/iocPhotron/xml/photronAttributes.xml
+++ b/iocs/photronIOC/iocBoot/iocPhotron/xml/photronAttributes.xml
@@ -4,10 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="https://github.com/areaDetector/ADCore/blob/master/iocBoot/NDAttributes.xsd"
     >
-    <!--Attribute name="CurrentEGU"          type="EPICS_PV" source="S:SRcurrentAI.EGU"            dbrtype="DBR_NATIVE"  description="Storage ring current units"/>
-    <Attribute name="Current"             type="EPICS_PV" source="S:SRcurrentAI"                dbrtype="DBR_NATIVE"  description="Storage ring current"/>
-    <Attribute name="SourceEnergy"        type="EPICS_PV" source="ID32:Energy"                  dbrtype="DBR_NATIVE"  description="Undulator energy"/>
-    <Attribute name="SourceEnergyEGU"     type="EPICS_PV" source="ID32:Energy.EGU"              dbrtype="DBR_NATIVE"  description="Undulator energy units"/-->
     <Attribute name="Manufacturer"        type="PARAM"    source="MANUFACTURER"                 datatype="STRING"     description="Camera manufacturer"/>
     <Attribute name="Model"               type="PARAM"    source="MODEL"                        datatype="STRING"     description="Camera model"/>
     <Attribute name="MaxSizeX"            type="PARAM"    source="MAX_SIZE_X"                   datatype="INT"        description="Sensor X Size"/>
@@ -18,6 +14,12 @@
     <Attribute name="TimeStamp"           type="PARAM"    source="TIME_STAMP"                   datatype="DOUBLE"     description="Time Stamp"/>
     <Attribute name="TimeStampSec"        type="PARAM"    source="EPICS_TS_SEC"                 datatype="INT"        description="EPICS Seconds"/>
     <Attribute name="TimeStampNSec"       type="PARAM"    source="EPICS_TS_NSEC"                datatype="INT"        description="EPICS Nanoseconds"/-->
+    <Attribute name="DateTimeStart"       type="EPICS_PV" source="S:IOC:timeOfDayISO8601"       dbrtype="DBR_STRING"/>
+    <Attribute name="DateTimeEnd"         type="EPICS_PV" source="S:IOC:timeOfDayISO8601"       dbrtype="DBR_STRING"/>
+    <Attribute name="Current"             type="EPICS_PV" source="S:SRcurrentAI"                dbrtype="DBR_DOUBLE"/>
+    <Attribute name="TopUpStatus"         type="EPICS_PV" source="S:TopUpStatus"                dbrtype="DBR_ENUM"/>
+    <!--<Attribute name="SourceEnergy"        type="EPICS_PV" source="ID32ds:Energy.VAL"            dbrtype="DBR_DOUBLE"/>
+    <Attribute name="SourceGap"           type="EPICS_PV" source="ID32ds:Gap.VAL"               dbrtype="DBR_DOUBLE"/-->
     <Attribute name="SizeX"               type="PARAM"    source="SIZE_X"                       datatype="INT"        description="Image X Size"/>
     <Attribute name="SizeY"               type="PARAM"    source="SIZE_Y"                       datatype="INT"        description="Image Y Size"/>
     <Attribute name="MinX"                type="PARAM"    source="MIN_X"                        datatype="INT"        description="Image X Position"/>


### PR DESCRIPTION
you were correct about the roi lables. I renamed them here and also fixed them in the txm xml files.
I also added time stamps for the start/end of data collection plus current and top-up status. These are all beamline independent. 